### PR TITLE
Yuxuan: update on PRT renderer dependency

### DIFF
--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -5,7 +5,13 @@
 
 :warning: For **EGL** headless rendering (without screen, such as clusters), please `export PYOPENGL_PLATFORM=egl` before running these scripts, otherwise, `unset PYOPENGL_PLATFORM`.
 
-:warning: If the program runs so slowly and is stuck in `mesh.ray.intersects_any`, uninstall and reinstall `pyembree` and `trimesh`, more details in [issue #62](https://github.com/YuliangXiu/ICON/issues/62).
+:warning: If the program runs so slowly and is stuck in `mesh.ray.intersects_any`, ~~uninstall and reinstall `pyembree` and `trimesh`, more details in [issue #62](https://github.com/YuliangXiu/ICON/issues/62)~~ it's because the trimesh is using the default triangle intersection function. Use `Pyembree` will accelerate the intersection computation. You can install `embree`, `pyembree`, `trimesh` via
+```
+conda install -c conda-forge embree=2.17.7
+conda install -c conda-forge pyembree
+```
+and test the installation via
+`from pyembree import rtcore_scene` and `print(trimesh.ray.ray_pyembree.error)`. If the error is `ray_pyembree has no attribute error`, then you are good to go.
 
 ## THuman2.0
 

--- a/lib/renderer/prt_util.py
+++ b/lib/renderer/prt_util.py
@@ -158,7 +158,7 @@ def computePRT(mesh_path, scale, n, order):
             hits = mesh.ray.intersects_any(origins + delta * normals, vectors)
             nohits = np.logical_and(front, np.logical_not(hits))
 
-            PRT = (nohits.astype(np.float) * dots)[:, None] * SH
+            PRT = (nohits.astype(np.float32) * dots)[:, None] * SH
 
             if PRT_all is not None:
                 PRT_all += (PRT.reshape(-1, n, SH.shape[1]).sum(1))


### PR DESCRIPTION
- resolve the issue of slow trimesh.ray.intersect_any() by proper installation instruction on `embree` and`pyembree` as well as simple yet effective testing function.
- resolve issue with incompatibility for numpy > 1.20 (np.float -> np.float32)